### PR TITLE
Add method to set font sizes for all controls

### DIFF
--- a/Remote/MilkwaveRemoteForm.cs
+++ b/Remote/MilkwaveRemoteForm.cs
@@ -179,7 +179,17 @@ namespace MilkwaveRemote {
       Opacity,
       GetState
     }
-
+    private void SetAllControlFontSizes(Control parent, float fontSize)
+    {
+        foreach (Control ctrl in parent.Controls)
+        {
+            ctrl.Font = new Font(ctrl.Font.FontFamily, fontSize, ctrl.Font.Style);
+            if (ctrl.HasChildren)
+            {
+                SetAllControlFontSizes(ctrl, fontSize);
+            }
+        }
+    }
     public MilkwaveRemoteForm() {
       InitializeComponent();
       FixNumericUpDownMouseWheel(this);
@@ -243,6 +253,7 @@ namespace MilkwaveRemote {
 
       tabControl.SelectedIndex = Settings.SelectedTabIndex;
       cboWindowTitle.SelectedIndex = 0;
+
     }
 
     private void MilkwaveRemoteForm_Load(object sender, EventArgs e) {
@@ -254,8 +265,8 @@ namespace MilkwaveRemote {
       ofd = new OpenFileDialog();
       ofd.Filter = "MilkDrop Presets|*.milk;*.milk2|All files (*.*)|*.*";
       ofd.RestoreDirectory = true;
-
-      helper.FillAudioDevices(cboAudioDevice);
+            SetAllControlFontSizes(this, 9f); // Sets all controls to font size 9
+            helper.FillAudioDevices(cboAudioDevice);
     }
 
     private IntPtr StartVisualizerIfNotFound() {


### PR DESCRIPTION
Introduced a new private method `SetAllControlFontSizes` in the `MilkwaveRemoteForm` class. This method recursively adjusts the font size of all controls within a specified parent control. It is invoked in the `MilkwaveRemoteForm_Load` method to ensure all controls are set to a font size of 9 upon form loading.