### PR TITLE
Multi-client pipe_server: reconnect + teardown hardening

### DIFF
--- a/Visualizer/milkwave/pipe_server.cpp
+++ b/Visualizer/milkwave/pipe_server.cpp
@@ -7,17 +7,19 @@
 #include <tlhelp32.h>  // CreateToolhelp32Snapshot
 #include <cstdlib>     // _wtoi, wcstof
 #include <cstring>     // wcsncmp, wcsstr
+#include <algorithm>   // std::find
 
 // Self-contained logging — uses OutputDebugStringA (works in all projects)
 #include <cstdio>  // vsnprintf
 #include <cstdarg>
+
 static void PipeLog(const char* fmt, ...) {
-  char buf[512];
-  va_list args;
-  va_start(args, fmt);
-  vsnprintf(buf, sizeof(buf), fmt, args);
-  va_end(args);
-  OutputDebugStringA(buf);
+    char buf[512];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    OutputDebugStringA(buf);
 }
 
 // ─── PipeServer ────────────────────────────────────────────────────────────────
@@ -25,468 +27,782 @@ static void PipeLog(const char* fmt, ...) {
 PipeServer::PipeServer() {}
 
 PipeServer::~PipeServer() {
-  Stop();
+    Stop();
 }
 
 void PipeServer::Start(HWND hTargetWindow, UINT wmIPCMessage, UINT wmSignalBase) {
-  if (m_bRunning.load())
-    return;
+    if (m_bRunning.load())
+        return;
 
-  m_hTargetWindow = hTargetWindow;
-  m_wmIPCMessage = wmIPCMessage;
-  m_wmSignalBase = wmSignalBase;
-  m_bShutdown.store(false);
+    m_hTargetWindow = hTargetWindow;
+    m_wmIPCMessage = wmIPCMessage;
+    m_wmSignalBase = wmSignalBase;
+    m_bShutdown.store(false);
 
-  // Build pipe name: \\.\pipe\Milkwave_<PID>
-  swprintf_s(m_szPipeName, L"\\\\.\\pipe\\Milkwave_%u", GetCurrentProcessId());
+    // Build pipe name: \\.\pipe\Milkwave_<PID>
+    swprintf_s(m_szPipeName, L"\\\\.\\pipe\\Milkwave_%u", GetCurrentProcessId());
 
-  // Create events
-  m_hShutdownEvent = CreateEventW(NULL, TRUE, FALSE, NULL);  // manual-reset
-  m_hOutEvent = CreateEventW(NULL, FALSE, FALSE, NULL);      // auto-reset
+    // Create shutdown event (manual-reset, shared across all threads)
+    m_hShutdownEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
 
-  // Start server thread
-  m_hServerThread = (HANDLE)_beginthreadex(
-      nullptr, 0, &PipeServer::ServerThread, this, 0, nullptr);
+    // Start accept thread
+    m_hServerThread = (HANDLE)_beginthreadex(
+        nullptr, 0, &PipeServer::ServerThread, this, 0, nullptr);
 
-  if (m_hServerThread) {
-    m_bRunning.store(true);
-    PipeLog("PipeServer: started on %ls\n", m_szPipeName);
-  } else {
-    PipeLog("PipeServer: failed to start thread\n");
-  }
+    if (m_hServerThread) {
+        m_bRunning.store(true);
+        PipeLog("PipeServer: started on %ls\n", m_szPipeName);
+    } else {
+        PipeLog("PipeServer: failed to start thread\n");
+    }
 }
 
 void PipeServer::Stop() {
-  if (!m_bRunning.load())
-    return;
+    if (!m_bRunning.load())
+        return;
 
-  m_bShutdown.store(true);
-  if (m_hShutdownEvent)
-    SetEvent(m_hShutdownEvent);
-  if (m_hOutEvent)
-    SetEvent(m_hOutEvent);
+    m_bShutdown.store(true);
+    if (m_hShutdownEvent)
+        SetEvent(m_hShutdownEvent);
 
-  // Cancel any pending I/O on the pipe
-  if (m_hPipe != INVALID_HANDLE_VALUE)
-    CancelIoEx(m_hPipe, NULL);
+    // Wake every handler: cancel its pending read, signal its out-event. Both
+    // handles belong to a context, so this runs under the clients lock -- a
+    // handler retires its own pipe under that same lock, and cancelling I/O on
+    // a handle it had already closed would target whatever the process opened
+    // next with the recycled value.
+    {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        for (auto* ctx : m_clients) {
+            if (ctx->hPipe != INVALID_HANDLE_VALUE)
+                CancelIoEx(ctx->hPipe, NULL);
+            if (ctx->hOutEvent)
+                SetEvent(ctx->hOutEvent);
+        }
+    }
 
-  if (m_hServerThread) {
-    WaitForSingleObject(m_hServerThread, 5000);
-    CloseHandle(m_hServerThread);
-    m_hServerThread = nullptr;
-  }
+    // Join the accept thread FIRST. It owns SweepFinished, which deletes
+    // contexts; retiring it is what makes the context pointers read below
+    // stable enough to touch at all.
+    if (m_hServerThread) {
+        WaitForSingleObject(m_hServerThread, 5000);
+        CloseHandle(m_hServerThread);
+        m_hServerThread = nullptr;
+    }
 
-  if (m_hPipe != INVALID_HANDLE_VALUE) {
-    DisconnectNamedPipe(m_hPipe);
-    CloseHandle(m_hPipe);
-    m_hPipe = INVALID_HANDLE_VALUE;
-  }
+    // Join the handlers against ONE budget rather than 3s each -- with sixteen
+    // listeners a single wedged client must not turn into a 48-second exit.
+    std::vector<PipeClientContext*> active;
+    {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        active = m_clients;
+    }
+    const ULONGLONG joinDeadline = GetTickCount64() + 3000;
+    for (auto* ctx : active) {
+        if (!ctx->hThread)
+            continue;
+        const ULONGLONG now = GetTickCount64();
+        WaitForSingleObject(ctx->hThread,
+                            now >= joinDeadline ? 0 : (DWORD)(joinDeadline - now));
+    }
 
-  if (m_hShutdownEvent) {
-    CloseHandle(m_hShutdownEvent);
-    m_hShutdownEvent = nullptr;
-  }
-  if (m_hOutEvent) {
-    CloseHandle(m_hOutEvent);
-    m_hOutEvent = nullptr;
-  }
+    // A handler that returned has already retired its pipe and moved itself to
+    // m_finishedClients, so whatever is still in m_clients is a thread that
+    // never came back. Its context is memory that thread may still be running
+    // inside and its pipe is a handle that thread may still close: freeing the
+    // one is a use-after-free and closing the other is a double-close. The
+    // process is on its way out, so leak them on purpose.
+    std::vector<PipeClientContext*> finished;
+    size_t nOrphans = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        nOrphans = m_clients.size();
+        m_clients.clear();
+        finished.swap(m_finishedClients);
+    }
+    if (nOrphans)
+        PipeLog("PipeServer: %zu handler(s) never exited; leaking their contexts\n", nOrphans);
 
-  m_bRunning.store(false);
-  m_bClientConnected.store(false);
-  PipeLog("PipeServer: stopped\n");
+    for (auto* ctx : finished) {
+        // A context reaches the finished list a few instructions before its
+        // thread actually returns, so this join is normally instant -- but its
+        // result, not its expiry, is what says the context is ours to free.
+        if (ctx->hThread && WaitForSingleObject(ctx->hThread, 1000) != WAIT_OBJECT_0) {
+            PipeLog("PipeServer: client #%d still running; leaking its context\n",
+                    ctx->nClientId);
+            continue;
+        }
+        if (ctx->hThread) CloseHandle(ctx->hThread);
+        if (ctx->hOutEvent) CloseHandle(ctx->hOutEvent);
+        delete ctx;
+    }
+
+    if (m_hShutdownEvent) { CloseHandle(m_hShutdownEvent); m_hShutdownEvent = nullptr; }
+
+    m_bRunning.store(false);
+    m_bClientConnected.store(false);
+    PipeLog("PipeServer: stopped\n");
 }
 
 void PipeServer::Send(const wchar_t* message) {
-  if (!message || !*message || m_bShutdown.load())
-    return;
-  {
-    std::lock_guard<std::mutex> lock(m_outMutex);
-    m_outQueue.emplace(message);
-  }
-  if (m_hOutEvent)
-    SetEvent(m_hOutEvent);
+    if (!message || !*message || m_bShutdown.load())
+        return;
+
+    std::lock_guard<std::mutex> lock(m_clientsMutex);
+    for (auto* ctx : m_clients) {
+        {
+            std::lock_guard<std::mutex> qlock(ctx->outMutex);
+            ctx->outQueue.emplace(message);
+        }
+        SetEvent(ctx->hOutEvent);
+    }
 }
 
 void PipeServer::Send(const std::wstring& message) {
-  Send(message.c_str());
+    Send(message.c_str());
+}
+
+int PipeServer::GetClientCount() const {
+    std::lock_guard<std::mutex> lock(m_clientsMutex);
+    return (int)m_clients.size();
+}
+
+void PipeServer::RemoveClient(PipeClientContext* ctx) {
+    std::lock_guard<std::mutex> lock(m_clientsMutex);
+
+    // The pipe is retired here rather than at the end of ClientHandler so that
+    // its handle is only ever touched while this lock is held. Stop() cancels
+    // I/O on the same handle, and a closed handle value is immediately free for
+    // any other CreateFile in the process to reuse.
+    if (ctx->hPipe != INVALID_HANDLE_VALUE) {
+        DisconnectNamedPipe(ctx->hPipe);
+        CloseHandle(ctx->hPipe);
+        ctx->hPipe = INVALID_HANDLE_VALUE;
+    }
+
+    auto it = std::find(m_clients.begin(), m_clients.end(), ctx);
+    if (it != m_clients.end())
+        m_clients.erase(it);
+    m_finishedClients.push_back(ctx);
+    m_bClientConnected.store(!m_clients.empty());
+}
+
+void PipeServer::SweepFinished() {
+    // Take the list, then join outside the lock. A handler on its way out does
+    // not need this mutex again, but waiting on a thread while holding a lock
+    // that thread might want is the shape deadlocks come in.
+    std::vector<PipeClientContext*> done;
+    {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        done.swap(m_finishedClients);
+    }
+
+    std::vector<PipeClientContext*> stillRunning;
+    for (auto* ctx : done) {
+        // A context lands on the finished list a few instructions before its
+        // thread returns, so this join almost always completes at once. When it
+        // does not, the thread is still executing inside the context and
+        // deleting it is a use-after-free -- so put it back and retry on the
+        // next sweep. Ignoring the join result is what made this unsafe.
+        if (ctx->hThread && WaitForSingleObject(ctx->hThread, 100) != WAIT_OBJECT_0) {
+            stillRunning.push_back(ctx);
+            continue;
+        }
+        if (ctx->hThread) CloseHandle(ctx->hThread);
+        if (ctx->hOutEvent) CloseHandle(ctx->hOutEvent);
+        delete ctx;
+    }
+
+    if (!stillRunning.empty()) {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        m_finishedClients.insert(m_finishedClients.end(),
+                                 stillRunning.begin(), stillRunning.end());
+    }
 }
 
 unsigned __stdcall PipeServer::ServerThread(void* pParam) {
-  PipeServer* self = static_cast<PipeServer*>(pParam);
-  self->ServerLoop();
-  return 0;
+    PipeServer* self = static_cast<PipeServer*>(pParam);
+    self->ServerLoop();
+    return 0;
 }
 
+unsigned __stdcall PipeServer::ClientThread(void* pParam) {
+    PipeClientContext* ctx = static_cast<PipeClientContext*>(pParam);
+    ctx->pServer->ClientHandler(ctx);
+    return 0;
+}
+
+// ─── Accept loop ────────────────────────────────────────────────────────────────
+
 void PipeServer::ServerLoop() {
-  // Security: allow same-user access (handles admin/non-admin mismatch)
-  SECURITY_ATTRIBUTES sa = {};
-  PSECURITY_DESCRIPTOR pSD = nullptr;
-  // SDDL: D:(A;;GA;;;WD) — grant all access to Everyone
-  // This is safe because named pipes are local-only and the pipe name
-  // includes the PID, so only someone who can enumerate processes can connect.
-  if (ConvertStringSecurityDescriptorToSecurityDescriptorA(
-          "D:(A;;GA;;;WD)", SDDL_REVISION_1, &pSD, NULL)) {
-    sa.nLength = sizeof(sa);
-    sa.lpSecurityDescriptor = pSD;
-    sa.bInheritHandle = FALSE;
-  }
-
-  while (!m_bShutdown.load()) {
-    // Create the pipe instance
-    m_hPipe = CreateNamedPipeW(
-        m_szPipeName,
-        PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
-        PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
-        1,      // max instances (single client)
-        65536,  // out buffer
-        65536,  // in buffer
-        0,      // default timeout
-        pSD ? &sa : NULL);
-
-    if (m_hPipe == INVALID_HANDLE_VALUE) {
-      PipeLog("PipeServer: CreateNamedPipe failed, err=%u\n", GetLastError());
-      Sleep(1000);
-      continue;
+    // Security: allow same-user access (handles admin/non-admin mismatch)
+    SECURITY_ATTRIBUTES sa = {};
+    PSECURITY_DESCRIPTOR pSD = nullptr;
+    // SDDL: D:(A;;GA;;;WD) — grant all access to Everyone
+    // This is safe because named pipes are local-only and the pipe name
+    // includes the PID, so only someone who can enumerate processes can connect.
+    if (ConvertStringSecurityDescriptorToSecurityDescriptorA(
+            "D:(A;;GA;;;WD)", SDDL_REVISION_1, &pSD, NULL)) {
+        sa.nLength = sizeof(sa);
+        sa.lpSecurityDescriptor = pSD;
+        sa.bInheritHandle = FALSE;
     }
 
-    // Wait for client connection (overlapped so we can cancel on shutdown)
-    OVERLAPPED ovConnect = {};
-    ovConnect.hEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
+    // Several listeners, armed at once (forgejo#25).
+    //
+    // A pipe is connectable only while an unconnected instance of it exists.
+    // This loop used to keep exactly ONE, and created the next only after
+    // building the client context, querying the client process image and
+    // spawning a handler thread -- so every connection left a window of
+    // milliseconds in which CreateFile on the pipe failed with
+    // ERROR_PIPE_BUSY. Anything reconnecting per command hit it on almost
+    // every attempt: 298 of 300 bare reconnects failed, measured.
+    //
+    // Creating the next instance earlier in the handoff is NOT enough, and
+    // measuring said so -- it still leaves nothing listening between a client
+    // closing and this thread next being scheduled. The fix is a small pool,
+    // each member with a ConnectNamedPipe already pending, so a client finds a
+    // free instance wherever this thread happens to be.
+    //
+    // A listener whose ConnectNamedPipe returns ERROR_PIPE_CONNECTED was
+    // claimed between CreateNamedPipeW and ConnectNamedPipe. That is a normal
+    // race, not an error: the connection is good, and there is no overlapped
+    // result to collect afterwards -- hence the immediate flag.
+    struct Listener {
+        HANDLE     hPipe = INVALID_HANDLE_VALUE;
+        HANDLE     hEvent = NULL;
+        OVERLAPPED ov = {};
+        bool       immediate = false;  // connected before we asked
+    };
 
-    BOOL connected = ConnectNamedPipe(m_hPipe, &ovConnect);
-    if (!connected) {
-      DWORD err = GetLastError();
-      if (err == ERROR_IO_PENDING) {
-        // Wait for either connection or shutdown
-        HANDLE waitHandles[] = {ovConnect.hEvent, m_hShutdownEvent};
-        DWORD waitResult = WaitForMultipleObjects(2, waitHandles, FALSE, INFINITE);
+    auto createInstance = [&]() -> HANDLE {
+        HANDLE h = CreateNamedPipeW(
+            m_szPipeName,
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+            PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+            PIPE_UNLIMITED_INSTANCES,
+            65536,   // out buffer
+            65536,   // in buffer
+            0,       // default timeout
+            pSD ? &sa : NULL);
+        if (h == INVALID_HANDLE_VALUE)
+            PipeLog("PipeServer: CreateNamedPipe failed, err=%u\n", GetLastError());
+        return h;
+    };
 
-        if (waitResult == WAIT_OBJECT_0 + 1 || m_bShutdown.load()) {
-          // Shutdown requested
-          CancelIoEx(m_hPipe, &ovConnect);
-          CloseHandle(ovConnect.hEvent);
-          CloseHandle(m_hPipe);
-          m_hPipe = INVALID_HANDLE_VALUE;
-          break;
+    // Create an instance and put a connect request on it.
+    auto arm = [&](Listener& L) -> bool {
+        L.hPipe = createInstance();
+        L.immediate = false;
+        if (L.hPipe == INVALID_HANDLE_VALUE)
+            return false;
+
+        ResetEvent(L.hEvent);
+        ZeroMemory(&L.ov, sizeof(L.ov));
+        L.ov.hEvent = L.hEvent;
+
+        if (ConnectNamedPipe(L.hPipe, &L.ov)) {
+            L.immediate = true;
+            SetEvent(L.hEvent);
+            return true;
         }
 
-        // Check if ConnectNamedPipe completed successfully
-        DWORD bytesTransferred;
-        if (!GetOverlappedResult(m_hPipe, &ovConnect, &bytesTransferred, FALSE)) {
-          CloseHandle(ovConnect.hEvent);
-          CloseHandle(m_hPipe);
-          m_hPipe = INVALID_HANDLE_VALUE;
-          continue;
+        const DWORD err = GetLastError();
+        if (err == ERROR_IO_PENDING)
+            return true;
+        if (err == ERROR_PIPE_CONNECTED) {
+            L.immediate = true;
+            SetEvent(L.hEvent);
+            return true;
         }
-      } else if (err == ERROR_PIPE_CONNECTED) {
-        // Client already connected before ConnectNamedPipe was called
-      } else {
-        // Real error
-        CloseHandle(ovConnect.hEvent);
-        CloseHandle(m_hPipe);
-        m_hPipe = INVALID_HANDLE_VALUE;
-        Sleep(100);
-        continue;
-      }
+
+        PipeLog("PipeServer: ConnectNamedPipe failed, err=%u\n", err);
+        CloseHandle(L.hPipe);
+        L.hPipe = INVALID_HANDLE_VALUE;
+        return false;
+    };
+
+    // Sixteen. The pool has to absorb two different bursts: a client
+    // reconnecting in a tight loop while this thread is still handing the
+    // previous one off, and several clients connecting at once -- Remote, the
+    // MCP server and a test harness together already exceeded eight. The
+    // buffer sizes above are quotas rather than upfront allocations, so an
+    // idle instance costs a handle.
+    const int kListeners = 16;
+    Listener listeners[kListeners];
+    for (int i = 0; i < kListeners; i++) {
+        listeners[i].hEvent = CreateEventW(NULL, TRUE, FALSE, NULL);  // manual-reset
+        arm(listeners[i]);
     }
-    CloseHandle(ovConnect.hEvent);
 
-    // Client is connected
-    m_bClientConnected.store(true);
-    PipeLog("PipeServer: client connected\n");
+    while (!m_bShutdown.load()) {
+        // Clean up finished handler threads
+        SweepFinished();
 
-    // ─── Read/Write loop ───────────────────────────────────────────────
-    // Single thread: alternate between checking for incoming and draining outgoing.
-    // Use overlapped reads with short waits so we can also send.
+        // Wait on every armed listener at once, plus shutdown.
+        HANDLE waits[kListeners + 1];
+        int    which[kListeners];
+        DWORD  n = 0;
+        for (int i = 0; i < kListeners; i++) {
+            if (listeners[i].hPipe == INVALID_HANDLE_VALUE)
+                continue;
+            which[n] = i;
+            waits[n++] = listeners[i].hEvent;
+        }
 
+        if (n == 0) {
+            // Nothing armed at all -- out of handles, or the name is unusable.
+            // Back off rather than spin.
+            Sleep(1000);
+            for (int i = 0; i < kListeners; i++)
+                arm(listeners[i]);
+            continue;
+        }
+
+        waits[n] = m_hShutdownEvent;
+        const DWORD w = WaitForMultipleObjects(n + 1, waits, FALSE, INFINITE);
+
+        if (w == WAIT_OBJECT_0 + n || m_bShutdown.load())
+            break;
+        if (w < WAIT_OBJECT_0 || w >= WAIT_OBJECT_0 + n) {
+            PipeLog("PipeServer: wait failed, err=%u\n", GetLastError());
+            Sleep(100);
+            continue;
+        }
+
+        Listener& L = listeners[which[w - WAIT_OBJECT_0]];
+
+        if (!L.immediate) {
+            DWORD bytesTransferred = 0;
+            if (!GetOverlappedResult(L.hPipe, &L.ov, &bytesTransferred, FALSE)) {
+                CloseHandle(L.hPipe);
+                L.hPipe = INVALID_HANDLE_VALUE;
+                arm(L);
+                continue;
+            }
+        }
+
+        // Take the connection and re-arm the slot at once, so the pool is back
+        // to strength before any of the handoff work below runs.
+        HANDLE hConnected = L.hPipe;
+        L.hPipe = INVALID_HANDLE_VALUE;
+        arm(L);
+
+        // Client connected -- create context and spawn handler thread
+        PipeClientContext* ctx = new PipeClientContext();
+        ctx->hPipe = hConnected;
+        ctx->pServer = this;
+        ctx->hOutEvent = CreateEventW(NULL, FALSE, FALSE, NULL);  // auto-reset
+
+        {
+            std::lock_guard<std::mutex> lock(m_clientsMutex);
+            ctx->nClientId = m_nNextClientId++;
+            m_clients.push_back(ctx);
+            m_bClientConnected.store(true);
+        }
+
+        // Capture client exe path
+        ULONG clientPid = 0;
+        if (GetNamedPipeClientProcessId(hConnected, &clientPid) && clientPid != 0) {
+            HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, clientPid);
+            if (hProc) {
+                DWORD pathLen = MAX_PATH;
+                if (QueryFullProcessImageNameW(hProc, 0, ctx->szClientExePath, &pathLen)) {
+                    // Update shared last-client path (most recent wins)
+                    wcscpy_s(m_szLastClientExePath, ctx->szClientExePath);
+                    PipeLog("PipeServer: client #%d exe: %ls\n", ctx->nClientId, ctx->szClientExePath);
+                }
+                CloseHandle(hProc);
+            }
+        }
+
+        // Start handler thread
+        ctx->hThread = (HANDLE)_beginthreadex(
+            nullptr, 0, &PipeServer::ClientThread, ctx, 0, nullptr);
+
+        if (!ctx->hThread) {
+            PipeLog("PipeServer: failed to start handler for client #%d\n", ctx->nClientId);
+            DisconnectNamedPipe(hConnected);
+            CloseHandle(hConnected);
+            CloseHandle(ctx->hOutEvent);
+            {
+                std::lock_guard<std::mutex> lock(m_clientsMutex);
+                auto it = std::find(m_clients.begin(), m_clients.end(), ctx);
+                if (it != m_clients.end()) m_clients.erase(it);
+                m_bClientConnected.store(!m_clients.empty());
+            }
+            delete ctx;
+            continue;
+        }
+
+        PipeLog("PipeServer: client #%d connected (total: %d)\n",
+                ctx->nClientId, GetClientCount());
+    }
+
+    // Listeners still waiting when the loop ended belong to nobody.
+    for (int i = 0; i < kListeners; i++) {
+        if (listeners[i].hPipe != INVALID_HANDLE_VALUE) {
+            CancelIoEx(listeners[i].hPipe, &listeners[i].ov);
+            CloseHandle(listeners[i].hPipe);
+        }
+        if (listeners[i].hEvent)
+            CloseHandle(listeners[i].hEvent);
+    }
+
+    if (pSD)
+        LocalFree(pSD);
+}
+
+// ─── Per-client read/write loop ─────────────────────────────────────────────────
+
+void PipeServer::ClientHandler(PipeClientContext* ctx) {
     OVERLAPPED ovRead = {};
     ovRead.hEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
 
     wchar_t readBuf[32768];  // 64KB in wchars
     bool readPending = false;
 
-    while (!m_bShutdown.load()) {
-      // Start an async read if not already pending
-      if (!readPending) {
-        ResetEvent(ovRead.hEvent);
-        DWORD bytesRead = 0;
-        BOOL ok = ReadFile(m_hPipe, readBuf, sizeof(readBuf) - sizeof(wchar_t),
-                           &bytesRead, &ovRead);
-        if (ok) {
-          // Completed immediately
-          readBuf[bytesRead / sizeof(wchar_t)] = L'\0';
-          DispatchMessage(readBuf, bytesRead / sizeof(wchar_t));
-        } else {
-          DWORD err = GetLastError();
-          if (err == ERROR_IO_PENDING) {
-            readPending = true;
-          } else if (err == ERROR_BROKEN_PIPE || err == ERROR_NO_DATA) {
-            break;  // client disconnected
-          } else {
-            break;  // unexpected error
-          }
-        }
-      }
+    // A message longer than readBuf arrives as several reads, each but the last
+    // reporting ERROR_MORE_DATA. Under PIPE_READMODE_MESSAGE the unread tail
+    // stays queued, so dispatching the first chunk and discarding the rest does
+    // not merely truncate this message -- the leftovers surface as the front of
+    // the NEXT one. Assemble the whole thing before dispatching it.
+    std::vector<wchar_t> assembled;
+    bool overlong = false;
 
-      // Wait on: read completion, outgoing data, or shutdown
-      HANDLE waitHandles[] = {ovRead.hEvent, m_hOutEvent, m_hShutdownEvent};
-      DWORD nHandles = readPending ? 3 : 2;
-      DWORD waitIdx = WaitForMultipleObjects(
-          nHandles, readPending ? waitHandles : waitHandles + 1,
-          FALSE, 50);  // 50ms timeout for responsiveness
+    // Every real command is a few dozen characters. This cap exists only so a
+    // malformed sender cannot make the server allocate without bound; the
+    // message is dropped and the connection stays usable.
+    const size_t kMaxMessageChars = 1u << 22;  // 4M wchars
 
-      if (m_bShutdown.load())
-        break;
-
-      // Check read completion
-      if (readPending) {
-        if (waitIdx == WAIT_OBJECT_0) {
-          DWORD bytesRead = 0;
-          if (GetOverlappedResult(m_hPipe, &ovRead, &bytesRead, FALSE)) {
-            readBuf[bytesRead / sizeof(wchar_t)] = L'\0';
-            DispatchMessage(readBuf, bytesRead / sizeof(wchar_t));
-            readPending = false;
-          } else {
-            DWORD err = GetLastError();
-            if (err == ERROR_BROKEN_PIPE || err == ERROR_NO_DATA) {
-              break;
-            } else if (err == ERROR_MORE_DATA) {
-              // Message too large for buffer — dispatch what we have, discard rest
-              readBuf[bytesRead / sizeof(wchar_t)] = L'\0';
-              DispatchMessage(readBuf, bytesRead / sizeof(wchar_t));
-              readPending = false;
+    auto absorb = [&](DWORD bytesRead, bool more) {
+        const size_t n = bytesRead / sizeof(wchar_t);
+        if (!overlong) {
+            if (assembled.size() + n > kMaxMessageChars) {
+                PipeLog("PipeServer: client #%d message over %zu chars, dropped\n",
+                        ctx->nClientId, kMaxMessageChars);
+                assembled.clear();
+                overlong = true;
+            } else {
+                assembled.insert(assembled.end(), readBuf, readBuf + n);
             }
-          }
         }
-      }
+        if (more)
+            return;  // the rest of this message is still queued on the pipe
+        if (!overlong && !assembled.empty()) {
+            assembled.push_back(L'\0');
+            DispatchMessage(assembled.data(), assembled.size() - 1);
+        }
+        assembled.clear();
+        overlong = false;
+    };
 
-      // Drain outgoing queue
-      {
-        std::lock_guard<std::mutex> lock(m_outMutex);
-        while (!m_outQueue.empty() && !m_bShutdown.load()) {
-          std::wstring& msg = m_outQueue.front();
-          DWORD bytesWritten = 0;
-          DWORD cbWrite = (DWORD)((msg.size() + 1) * sizeof(wchar_t));
-          OVERLAPPED ovWrite = {};
-          ovWrite.hEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
-          BOOL ok = WriteFile(m_hPipe, msg.c_str(), cbWrite, &bytesWritten, &ovWrite);
-          if (!ok && GetLastError() == ERROR_IO_PENDING) {
-            // Wait for write (with timeout)
-            DWORD wr = WaitForSingleObject(ovWrite.hEvent, 1000);
-            if (wr == WAIT_OBJECT_0)
-              GetOverlappedResult(m_hPipe, &ovWrite, &bytesWritten, FALSE);
-          }
-          CloseHandle(ovWrite.hEvent);
-          m_outQueue.pop();
+    while (!m_bShutdown.load()) {
+        // Start an async read if not already pending
+        if (!readPending) {
+            ResetEvent(ovRead.hEvent);
+            DWORD bytesRead = 0;
+            BOOL ok = ReadFile(ctx->hPipe, readBuf, sizeof(readBuf), &bytesRead, &ovRead);
+            if (ok) {
+                absorb(bytesRead, false);  // completed immediately
+            } else {
+                DWORD err = GetLastError();
+                if (err == ERROR_IO_PENDING) {
+                    readPending = true;
+                } else if (err == ERROR_MORE_DATA) {
+                    // Complete, but only the head of the message fit. The count
+                    // is not set on a failing return, so go and collect it.
+                    if (!GetOverlappedResult(ctx->hPipe, &ovRead, &bytesRead, FALSE) &&
+                        GetLastError() != ERROR_MORE_DATA)
+                        break;
+                    absorb(bytesRead, true);
+                } else {
+                    break;  // broken pipe, no data, or anything unexpected
+                }
+            }
         }
-      }
+
+        // Wait on: read completion, outgoing data, or shutdown
+        HANDLE waitHandles[] = { ovRead.hEvent, ctx->hOutEvent, m_hShutdownEvent };
+        DWORD nHandles = readPending ? 3 : 2;
+        DWORD waitIdx = WaitForMultipleObjects(
+            nHandles, readPending ? waitHandles : waitHandles + 1,
+            FALSE, 50);  // 50ms timeout for responsiveness
+
+        if (m_bShutdown.load())
+            break;
+
+        // Check read completion
+        if (readPending && waitIdx == WAIT_OBJECT_0) {
+            DWORD bytesRead = 0;
+            const BOOL got = GetOverlappedResult(ctx->hPipe, &ovRead, &bytesRead, FALSE);
+            const DWORD err = got ? ERROR_SUCCESS : GetLastError();
+            if (!got && err != ERROR_MORE_DATA) {
+                // Broken pipe, cancelled I/O, or anything unexpected: end the
+                // client. Leaving readPending set and looping is worse than a
+                // lost message -- ovRead.hEvent is manual-reset and nothing
+                // above resets it until the next read is armed, so the wait
+                // returns instantly and this loop spins on a full core.
+                break;
+            }
+            readPending = false;
+            absorb(bytesRead, err == ERROR_MORE_DATA);
+        }
+
+        // Drain outgoing queue
+        {
+            std::lock_guard<std::mutex> lock(ctx->outMutex);
+            while (!ctx->outQueue.empty() && !m_bShutdown.load()) {
+                std::wstring& msg = ctx->outQueue.front();
+                DWORD bytesWritten = 0;
+                DWORD cbWrite = (DWORD)((msg.size() + 1) * sizeof(wchar_t));
+                OVERLAPPED ovWrite = {};
+                ovWrite.hEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
+                BOOL ok = WriteFile(ctx->hPipe, msg.c_str(), cbWrite, &bytesWritten, &ovWrite);
+                if (!ok) {
+                    DWORD err = GetLastError();
+                    if (err == ERROR_IO_PENDING) {
+                        DWORD wr = WaitForSingleObject(ovWrite.hEvent, 1000);
+                        if (wr == WAIT_OBJECT_0)
+                            GetOverlappedResult(ctx->hPipe, &ovWrite, &bytesWritten, FALSE);
+                    } else if (err == ERROR_BROKEN_PIPE || err == ERROR_NO_DATA) {
+                        CloseHandle(ovWrite.hEvent);
+                        ctx->outQueue.pop();
+                        break;  // client disconnected during write
+                    }
+                }
+                CloseHandle(ovWrite.hEvent);
+                ctx->outQueue.pop();
+            }
+        }
     }
 
     // Cancel pending read
     if (readPending)
-      CancelIoEx(m_hPipe, &ovRead);
+        CancelIoEx(ctx->hPipe, &ovRead);
     CloseHandle(ovRead.hEvent);
 
-    // Disconnect and loop to accept next client
-    m_bClientConnected.store(false);
-    DisconnectNamedPipe(m_hPipe);
-    CloseHandle(m_hPipe);
-    m_hPipe = INVALID_HANDLE_VALUE;
-    PipeLog("PipeServer: client disconnected\n");
-
-    // Clear pending outgoing messages (stale for next client)
-    {
-      std::lock_guard<std::mutex> lock(m_outMutex);
-      std::queue<std::wstring> empty;
-      m_outQueue.swap(empty);
-    }
-  }
-
-  if (pSD)
-    LocalFree(pSD);
+    // RemoveClient retires the pipe and publishes ctx to m_finishedClients,
+    // where SweepFinished on the accept thread -- or Stop -- may delete it
+    // before the next line runs. Nothing after it may dereference ctx, so take
+    // what the log needs while the context is still ours.
+    const int nClientId = ctx->nClientId;
+    RemoveClient(ctx);
+    PipeLog("PipeServer: client #%d disconnected\n", nClientId);
 }
+
+// ─── Message dispatch ───────────────────────────────────────────────────────────
 
 void PipeServer::DispatchMessage(const wchar_t* message, size_t len) {
-  if (!message || len == 0 || !m_hTargetWindow)
-    return;
+    if (!message || len == 0 || !m_hTargetWindow) {
+        PipeLog("PipeServer::DispatchMessage: null/empty (msg=%p len=%zu hwnd=%p)\n",
+                message, len, m_hTargetWindow);
+        return;
+    }
 
-  // Check for SIGNAL| prefix — these map to PostMessage calls
-  if (wcsncmp(message, L"SIGNAL|", 7) == 0) {
-    if (DispatchSignal(message + 7))
-      return;
-  }
+    // Length first: PipeLog formats into 512 bytes, so a long message used to
+    // push the one field worth reading off the end of its own log line.
+    PipeLog("PipeServer: received len=%zu [%ls]\n", len, message);
 
-  // Check for SPOUT_SENDER= prefix — maps to WM_MW_IPC_MESSAGE with dwData=WM_MW_SETSPOUTSENDER
-  if (wcsncmp(message, L"SPOUT_SENDER=", 13) == 0) {
-    const wchar_t* name = message + 13;
-    size_t nameLen = wcslen(name);
-    wchar_t* copy = (wchar_t*)malloc((nameLen + 1) * sizeof(wchar_t));
+    // Check for SIGNAL| prefix — these map to PostMessage calls.
+    //
+    // A SIGNAL| the table does not carry is finished here. Falling through used
+    // to post the raw "SIGNAL|..." string on as a generic IPC message, and
+    // Engine::LaunchMessage matches the same prefix and calls DispatchSignal
+    // again -- the identical failure, one heap copy and one window message
+    // later. This is NOT the script-engine fallback that unrecognised keywords
+    // depend on: LaunchMessage claims the SIGNAL| prefix and returns, so a bad
+    // signal never reached ExecuteScriptLine in the first place.
+    if (wcsncmp(message, L"SIGNAL|", 7) == 0) {
+        if (!DispatchSignal(message + 7))
+            PipeLog("PipeServer: unknown signal [%ls]\n", message + 7);
+        return;
+    }
+
+    // Check for SPOUT_SENDER= prefix — maps to WM_MW_IPC_MESSAGE with dwData=WM_MW_SETSPOUTSENDER
+    if (wcsncmp(message, L"SPOUT_SENDER=", 13) == 0) {
+        const wchar_t* name = message + 13;
+        size_t nameLen = wcslen(name);
+        wchar_t* copy = (wchar_t*)malloc((nameLen + 1) * sizeof(wchar_t));
+        if (copy) {
+            wcscpy_s(copy, nameLen + 1, name);
+            // Use the SETSPOUTSENDER constant as dwData (base + 108)
+            // The engine handler checks for this in the IPC message
+            UINT wmSetSpoutSender = m_wmSignalBase + 108;
+            if (!PostMessageW(m_hTargetWindow, m_wmIPCMessage,
+                              (WPARAM)wmSetSpoutSender, (LPARAM)copy)) {
+                free(copy);
+            }
+        }
+        return;
+    }
+
+    // All other messages: heap-copy and post as WM_MW_IPC_MESSAGE with dwData=1
+    size_t msgLen = wcslen(message);
+    wchar_t* copy = (wchar_t*)malloc((msgLen + 1) * sizeof(wchar_t));
     if (copy) {
-      wcscpy_s(copy, nameLen + 1, name);
-      // Use the SETSPOUTSENDER constant as dwData (base + 108)
-      // The engine handler checks for this in the IPC message
-      UINT wmSetSpoutSender = m_wmSignalBase + 108;
-      if (!PostMessageW(m_hTargetWindow, m_wmIPCMessage,
-                        (WPARAM)wmSetSpoutSender, (LPARAM)copy)) {
-        free(copy);
-      }
+        wcscpy_s(copy, msgLen + 1, message);
+        if (!PostMessageW(m_hTargetWindow, m_wmIPCMessage, (WPARAM)1, (LPARAM)copy)) {
+            PipeLog("PipeServer: PostMessage FAILED err=%u\n", GetLastError());
+            free(copy);
+        } else {
+            PipeLog("PipeServer: posted IPC message to hwnd=%p\n", m_hTargetWindow);
+        }
     }
-    return;
-  }
-
-  // All other messages: heap-copy and post as WM_MW_IPC_MESSAGE with dwData=1
-  size_t msgLen = wcslen(message);
-  wchar_t* copy = (wchar_t*)malloc((msgLen + 1) * sizeof(wchar_t));
-  if (copy) {
-    wcscpy_s(copy, msgLen + 1, message);
-    if (!PostMessageW(m_hTargetWindow, m_wmIPCMessage, (WPARAM)1, (LPARAM)copy)) {
-      free(copy);
-    }
-  }
 }
 
+// ─── Signal dispatch table ─────────────────────────────────────────────────────
+struct SignalEntry {
+    const wchar_t* name;
+    int offset;       // added to m_wmSignalBase
+    bool hasValue;    // true = uses KEY=VALUE format (wcsncmp + send parsed value)
+    WPARAM wparam;    // wParam for a simple signal; ignored when hasValue
+};
+
+static const SignalEntry s_signalTable[] = {
+    // Simple signals (exact match, no value)
+    { L"NEXT_PRESET",          100, false, 0 },
+    { L"PREV_PRESET",          101, false, 0 },
+    { L"COVER_CHANGED",        102, false, 0 },
+    { L"SPRITE_MODE",          103, false, 0 },
+    { L"MESSAGE_MODE",         104, false, 0 },
+    { L"CAPTURE",              105, false, 0 },
+    { L"FULLSCREEN",           160, false, MW_FS_TOGGLE },
+    { L"WATERMARK",            161, false, 0 },
+    { L"BORDERLESS_FS",        162, false, 0 },
+    // MDropDX12-only display signals (SHOW_COVER 110, STRETCH 163, MIRROR 164,
+    // MIRROR_WM 165, MIRROR_INDEPENDENT 167, ALWAYS_ON_TOP 168) are omitted:
+    // Milkwave's WndProc has no handler for those offsets.
+    // KEY=VALUE signals (prefix match, value parsed as int into WPARAM)
+    { L"SETVIDEODEVICE",       106, true , 0 },
+    { L"ENABLEVIDEOMIX",       107, true , 0 },
+    { L"ENABLESPOUTMIX",       109, true , 0 },
+    { L"SET_INPUTMIX_OPACITY", 150, true , 0 },
+    { L"SET_INPUTMIX_ONTOP",   152, true , 0 },
+};
+
 bool PipeServer::DispatchSignal(const wchar_t* signal) {
-  if (!signal || !m_hTargetWindow)
-    return false;
+    if (!signal || !m_hTargetWindow)
+        return false;
 
-  // Parse: NEXT_PRESET, PREV_PRESET, etc.
-  // Uses m_wmSignalBase (WM_APP for MDropDX12, WM_USER for Milkwave)
-  if (wcscmp(signal, L"NEXT_PRESET") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 100, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"PREV_PRESET") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 101, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"COVER_CHANGED") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 102, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"SPRITE_MODE") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 103, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"MESSAGE_MODE") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 104, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"CAPTURE") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 105, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"FULLSCREEN") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 160, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"WATERMARK") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 161, 0, 0);
-    return true;
-  }
-  if (wcscmp(signal, L"BORDERLESS_FS") == 0) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 162, 0, 0);
-    return true;
-  }
+    // Parse: NEXT_PRESET, PREV_PRESET, etc.
+    // Uses m_wmSignalBase (WM_APP for MDropDX12, WM_USER for Milkwave)
+    for (const auto& entry : s_signalTable) {
+        if (!entry.hasValue) {
+            // Exact match for simple signals
+            if (wcscmp(signal, entry.name) == 0) {
+                PostMessageW(m_hTargetWindow, m_wmSignalBase + entry.offset,
+                             entry.wparam, 0);
+                return true;
+            }
+        } else {
+            // Prefix match for KEY=VALUE signals
+            size_t nameLen = wcslen(entry.name);
+            if (wcsncmp(signal, entry.name, nameLen) == 0 && signal[nameLen] == L'=') {
+                const wchar_t* value = signal + nameLen + 1;
+                PostMessageW(m_hTargetWindow, m_wmSignalBase + entry.offset, (WPARAM)_wtoi(value), 0);
+                return true;
+            }
+        }
+    }
 
-  // Signals with values: KEY=VALUE
-  const wchar_t* eq = wcschr(signal, L'=');
-  if (!eq)
-    return false;
+    // Special case: SET_INPUTMIX_LUMAKEY parses threshold|softness into WPARAM and LPARAM
+    const wchar_t kLumaKey[] = L"SET_INPUTMIX_LUMAKEY";
+    const size_t kLumaKeyLen = _countof(kLumaKey) - 1;
+    if (wcsncmp(signal, kLumaKey, kLumaKeyLen) == 0 && signal[kLumaKeyLen] == L'=') {
+        const wchar_t* value = signal + kLumaKeyLen + 1;
+        int threshold = _wtoi(value);
+        int softness = 0;
+        const wchar_t* pipe = wcschr(value, L'|');
+        if (pipe)
+            softness = _wtoi(pipe + 1);
+        PostMessageW(m_hTargetWindow, m_wmSignalBase + 151, (WPARAM)threshold, (LPARAM)softness);
+        return true;
+    }
 
-  // Extract key and value
-  size_t keyLen = eq - signal;
-  const wchar_t* value = eq + 1;
-
-  if (wcsncmp(signal, L"ENABLESPOUTMIX", keyLen) == 0 && keyLen == 14) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 109, (WPARAM)_wtoi(value), 0);
-    return true;
-  }
-  if (wcsncmp(signal, L"SET_INPUTMIX_OPACITY", keyLen) == 0 && keyLen == 20) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 150, (WPARAM)_wtoi(value), 0);
-    return true;
-  }
-  if (wcsncmp(signal, L"SET_INPUTMIX_ONTOP", keyLen) == 0 && keyLen == 18) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 152, (WPARAM)_wtoi(value), 0);
-    return true;
-  }
-  if (wcsncmp(signal, L"SET_INPUTMIX_LUMAKEY", keyLen) == 0 && keyLen == 20) {
-    // Value format: threshold|softness
-    int threshold = _wtoi(value);
-    int softness = 0;
-    const wchar_t* pipe = wcschr(value, L'|');
-    if (pipe)
-      softness = _wtoi(pipe + 1);
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 151, (WPARAM)threshold, (LPARAM)softness);
-    return true;
-  }
-  if (wcsncmp(signal, L"ENABLEVIDEOMIX", keyLen) == 0 && keyLen == 14) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 107, (WPARAM)_wtoi(value), 0);
-    return true;
-  }
-  if (wcsncmp(signal, L"SETVIDEODEVICE", keyLen) == 0 && keyLen == 14) {
-    PostMessageW(m_hTargetWindow, m_wmSignalBase + 106, (WPARAM)_wtoi(value), 0);
-    return true;
-  }
-
-  return false;  // unknown signal
+    return false;  // unknown signal
 }
 
 // ─── Second-instance forwarding ────────────────────────────────────────────────
 
 bool PipeSendToExistingInstance(const wchar_t* message) {
-  if (!message || !*message)
-    return false;
+    if (!message || !*message)
+        return false;
 
-  // Enumerate processes to find other instances of the current exe
-  HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-  if (hSnap == INVALID_HANDLE_VALUE)
-    return false;
+    // Enumerate processes to find other instances of the current exe
+    HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (hSnap == INVALID_HANDLE_VALUE)
+        return false;
 
-  DWORD myPid = GetCurrentProcessId();
+    DWORD myPid = GetCurrentProcessId();
 
-  // Get our exe filename (just the name, no path)
-  wchar_t myExePath[MAX_PATH];
-  GetModuleFileNameW(NULL, myExePath, MAX_PATH);
-  const wchar_t* myExeName = wcsrchr(myExePath, L'\\');
-  myExeName = myExeName ? myExeName + 1 : myExePath;
+    // Get our exe filename (just the name, no path)
+    wchar_t myExePath[MAX_PATH];
+    GetModuleFileNameW(NULL, myExePath, MAX_PATH);
+    const wchar_t* myExeName = wcsrchr(myExePath, L'\\');
+    myExeName = myExeName ? myExeName + 1 : myExePath;
 
-  PROCESSENTRY32W pe = {};
-  pe.dwSize = sizeof(pe);
-  bool sent = false;
+    PROCESSENTRY32W pe = {};
+    pe.dwSize = sizeof(pe);
+    bool sent = false;
 
-  if (Process32FirstW(hSnap, &pe)) {
-    do {
-      if (pe.th32ProcessID == myPid)
-        continue;
-      if (_wcsicmp(pe.szExeFile, myExeName) != 0)
-        continue;
+    if (Process32FirstW(hSnap, &pe)) {
+        do {
+            if (pe.th32ProcessID == myPid)
+                continue;
+            if (_wcsicmp(pe.szExeFile, myExeName) != 0)
+                continue;
 
-      // Found another instance — try to connect to its pipe
-      wchar_t pipeName[64];
-      swprintf_s(pipeName, L"\\\\.\\pipe\\Milkwave_%u", pe.th32ProcessID);
+            // Same FILENAME is not the same install. Distribution is a portable
+            // zip, and running one copy of the folder per display is the
+            // supported way to get a different preset on each screen -- so
+            // several unrelated MDropDX12.exe processes is the normal case, not
+            // an exotic one. Matching on the name alone forwarded a
+            // double-clicked preset to whichever the process snapshot happened
+            // to yield first, and then exited silently, so the preset opened on
+            // a window the user was not looking at.
+            //
+            // Compare the full image path instead. If it cannot be read, skip:
+            // forwarding to an instance that cannot be proven to be this same
+            // install is the behaviour being fixed.
+            {
+                HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+                                           FALSE, pe.th32ProcessID);
+                if (!hProc)
+                    continue;
+                wchar_t theirPath[MAX_PATH] = {};
+                DWORD len = MAX_PATH;
+                const BOOL got = QueryFullProcessImageNameW(hProc, 0, theirPath, &len);
+                CloseHandle(hProc);
+                if (!got || _wcsicmp(theirPath, myExePath) != 0)
+                    continue;
+            }
 
-      HANDLE hPipe = CreateFileW(
-          pipeName,
-          GENERIC_READ | GENERIC_WRITE,
-          0, NULL,
-          OPEN_EXISTING,
-          0, NULL);
+            // Found another instance — try to connect to its pipe
+            wchar_t pipeName[64];
+            swprintf_s(pipeName, L"\\\\.\\pipe\\Milkwave_%u", pe.th32ProcessID);
 
-      if (hPipe != INVALID_HANDLE_VALUE) {
-        // Set message read mode
-        DWORD mode = PIPE_READMODE_MESSAGE;
-        SetNamedPipeHandleState(hPipe, &mode, NULL, NULL);
+            HANDLE hPipe = CreateFileW(
+                pipeName,
+                GENERIC_READ | GENERIC_WRITE,
+                0, NULL,
+                OPEN_EXISTING,
+                0, NULL);
 
-        DWORD cbWrite = (DWORD)((wcslen(message) + 1) * sizeof(wchar_t));
-        DWORD written = 0;
-        WriteFile(hPipe, message, cbWrite, &written, NULL);
-        CloseHandle(hPipe);
-        sent = true;
-        break;  // sent to first found instance
-      }
-    } while (Process32NextW(hSnap, &pe));
-  }
+            if (hPipe != INVALID_HANDLE_VALUE) {
+                // Set message read mode
+                DWORD mode = PIPE_READMODE_MESSAGE;
+                SetNamedPipeHandleState(hPipe, &mode, NULL, NULL);
 
-  CloseHandle(hSnap);
-  return sent;
+                DWORD cbWrite = (DWORD)((wcslen(message) + 1) * sizeof(wchar_t));
+                DWORD written = 0;
+                WriteFile(hPipe, message, cbWrite, &written, NULL);
+                CloseHandle(hPipe);
+                sent = true;
+                break;  // sent to first found instance
+            }
+        } while (Process32NextW(hSnap, &pe));
+    }
+
+    CloseHandle(hSnap);
+    return sent;
 }

--- a/Visualizer/milkwave/pipe_server.h
+++ b/Visualizer/milkwave/pipe_server.h
@@ -2,6 +2,7 @@
 // pipe_server.h — Named Pipe IPC server for Milkwave visualizers
 // Replaces the hidden WM_COPYDATA IPC window with a named pipe.
 // Pipe name: \\.\pipe\Milkwave_<PID>
+// Supports multiple concurrent clients (e.g., MilkwaveRemote + MCP).
 
 #ifndef PIPE_SERVER_H
 #define PIPE_SERVER_H
@@ -9,62 +10,101 @@
 #include <windows.h>
 #include <atomic>
 #include <mutex>
-#include <condition_variable>
 #include <queue>
 #include <string>
+#include <vector>
+
+// WM_MW_FULLSCREEN wParam convention (forgejo#23).
+//
+// The Displays tab needs absolute enter/exit, so 1 and 0 were given those
+// meanings -- which silently redefined the 0 that every SIGNAL| and script
+// caller was already sending. DispatchSignal can only send a wParam a table
+// entry carries, so SIGNAL|FULLSCREEN meant "ensure exit" and could never
+// enter fullscreen. The toggle needs a value of its own, and every sender has
+// to name the same one, hence these live here rather than at each call site.
+#define MW_FS_EXIT    0  // ensure exit, whatever the current state
+#define MW_FS_ENTER   1  // ensure enter
+#define MW_FS_TOGGLE  2  // toggle (SIGNAL|FULLSCREEN, the FULLSCREEN script command)
+
+class PipeServer;
+
+// Per-client connection context — one per connected client, owned by PipeServer.
+struct PipeClientContext {
+    HANDLE                    hPipe = INVALID_HANDLE_VALUE;
+    HANDLE                    hThread = nullptr;
+    HANDLE                    hOutEvent = nullptr;   // auto-reset, wakes handler for outgoing
+    std::queue<std::wstring>  outQueue;
+    std::mutex                outMutex;
+    wchar_t                   szClientExePath[MAX_PATH] = {};
+    PipeServer*               pServer = nullptr;     // back-pointer for dispatch/shutdown
+    int                       nClientId = 0;         // monotonic ID for logging
+};
 
 class PipeServer {
- public:
-  PipeServer();
-  ~PipeServer();
+public:
+    PipeServer();
+    ~PipeServer();
 
-  // Start the pipe server. hTargetWindow receives wmIPCMessage posts.
-  // wmIPCMessage: the custom IPC message constant (WM_APP+9 in MDropDX12, WM_USER+200 in Milkwave).
-  // wmSignalBase: base for SIGNAL| dispatch (WM_APP in MDropDX12, WM_USER in Milkwave).
-  //   SIGNAL|NEXT_PRESET → PostMessage(wmSignalBase + 100), etc.
-  void Start(HWND hTargetWindow, UINT wmIPCMessage, UINT wmSignalBase = 0x8000 /*WM_APP*/);
-  void Stop();
+    // Start the pipe server. hTargetWindow receives wmIPCMessage posts.
+    // wmIPCMessage: the custom IPC message constant (WM_APP+9 in MDropDX12, WM_USER+200 in Milkwave).
+    // wmSignalBase: base for SIGNAL| dispatch (WM_APP in MDropDX12, WM_USER in Milkwave).
+    //   SIGNAL|NEXT_PRESET → PostMessage(wmSignalBase + 100), etc.
+    void Start(HWND hTargetWindow, UINT wmIPCMessage, UINT wmSignalBase = 0x8000 /*WM_APP*/);
+    void Stop();
 
-  // Enqueue an outgoing message to the connected client (fire-and-forget).
-  void Send(const wchar_t* message);
-  void Send(const std::wstring& message);
+    // Enqueue an outgoing message to all connected clients (fire-and-forget).
+    void Send(const wchar_t* message);
+    void Send(const std::wstring& message);
 
-  bool IsRunning() const { return m_bRunning.load(); }
-  bool IsConnected() const { return m_bClientConnected.load(); }
+    bool IsRunning() const { return m_bRunning.load(); }
+    bool IsConnected() const { return m_bClientConnected.load(); }
+    int  GetClientCount() const;
 
-  // Get the pipe name (for display in settings UI)
-  const wchar_t* GetPipeName() const { return m_szPipeName; }
+    // Get the pipe name (for display in settings UI)
+    const wchar_t* GetPipeName() const { return m_szPipeName; }
 
- private:
-  static unsigned __stdcall ServerThread(void* pParam);
-  void ServerLoop();
+    // Get the full exe path of the last connected client (empty if never connected)
+    const wchar_t* GetLastClientExePath() const { return m_szLastClientExePath; }
 
-  // Parse incoming pipe messages and dispatch to the target window
-  void DispatchMessage(const wchar_t* message, size_t len);
+    // Parse SIGNAL| messages into PostMessage calls (public for LaunchMessage routing)
+    bool DispatchSignal(const wchar_t* signal);
 
-  // Parse SIGNAL| messages into PostMessage calls
-  bool DispatchSignal(const wchar_t* signal);
+private:
+    static unsigned __stdcall ServerThread(void* pParam);
+    static unsigned __stdcall ClientThread(void* pParam);
+    void ServerLoop();
+    void ClientHandler(PipeClientContext* ctx);
 
-  HWND m_hTargetWindow = nullptr;
-  UINT m_wmIPCMessage = 0;       // WM_MW_IPC_MESSAGE equivalent
-  UINT m_wmSignalBase = 0x8000;  // base for SIGNAL| dispatch (WM_APP or WM_USER)
-  HANDLE m_hPipe = INVALID_HANDLE_VALUE;
+    // Parse incoming pipe messages and dispatch to the target window
+    void DispatchMessage(const wchar_t* message, size_t len);
 
-  std::atomic<bool> m_bRunning{false};
-  std::atomic<bool> m_bShutdown{false};
-  std::atomic<bool> m_bClientConnected{false};
+    // Move client from active to finished list (called by handler on disconnect)
+    void RemoveClient(PipeClientContext* ctx);
 
-  // Outgoing message queue
-  std::queue<std::wstring> m_outQueue;
-  std::mutex m_outMutex;
-  HANDLE m_hOutEvent = nullptr;  // signaled when queue has data
+    // Join and delete finished client handler threads
+    void SweepFinished();
 
-  // Shutdown event (cancels ConnectNamedPipe / ReadFile waits)
-  HANDLE m_hShutdownEvent = nullptr;
+    HWND   m_hTargetWindow = nullptr;
+    UINT   m_wmIPCMessage = 0;      // WM_MW_IPC_MESSAGE equivalent
+    UINT   m_wmSignalBase = 0x8000; // base for SIGNAL| dispatch (WM_APP or WM_USER)
 
-  HANDLE m_hServerThread = nullptr;
+    std::atomic<bool> m_bRunning{false};
+    std::atomic<bool> m_bShutdown{false};
+    std::atomic<bool> m_bClientConnected{false};
 
-  wchar_t m_szPipeName[64] = {};
+    // Client tracking (protected by m_clientsMutex)
+    std::vector<PipeClientContext*> m_clients;          // active clients
+    std::vector<PipeClientContext*> m_finishedClients;  // awaiting cleanup
+    mutable std::mutex              m_clientsMutex;
+    int                             m_nNextClientId = 0;
+
+    // Shutdown event (manual-reset, shared across all threads)
+    HANDLE m_hShutdownEvent = nullptr;
+
+    HANDLE m_hServerThread = nullptr;
+
+    wchar_t m_szPipeName[64] = {};
+    wchar_t m_szLastClientExePath[MAX_PATH] = {};
 };
 
 // Connect to a running visualizer's pipe by PID and send a message.
@@ -72,4 +112,4 @@ class PipeServer {
 // Returns true if message was sent successfully.
 bool PipeSendToExistingInstance(const wchar_t* message);
 
-#endif  // PIPE_SERVER_H
+#endif // PIPE_SERVER_H


### PR DESCRIPTION
Hi Ike — thanks for v4.0; the named-pipe IPC has been a pleasure to build on.

### What it does
Swaps the single-client pipe server for the multi-client evolution of the same file from my DX12 fork (MDropDX12), so the visualizer can serve more than one IPC client at once — e.g. the Remote plus a small helper connected at the same time.

It carries along the robustness fixes that came out of that fork:

- **A small pre-armed listener pool** — rapid reconnects stop hitting `ERROR_PIPE_BUSY`.
- **Client-teardown lifetime fixes** — no use-after-free when a client disconnects, and no unchecked joins / double-close at shutdown.
- **Read-loop fixes** — `ERROR_MORE_DATA` is now accumulated (an oversized message no longer truncates and corrupts the *next* read); an unmatched `SIGNAL|` stops at the pipe server; and an unexpected overlapped-read failure ends that client instead of spinning a core.

### Compatibility
- The signal table matches Milkwave's current set, so there's no behavior change for any signal it already handles. `FULLSCREEN` still toggles.
- `Start`/`Stop`/`Send`/`IsConnected`/`GetPipeName` keep their signatures. `Send()` now fans out to all connected clients — the existing callers are preset-change notifications, so that's the intended effect.

### Testing
- Builds clean under the repo's v143 CLI build (`cl.exe`, `Release|Win32`, 0 warnings / 0 errors).
- Same code runs in MDropDX12, exercised there by its pipe teardown/reconnect tests and a 38-case IPC conformance suite.

Happy to adjust or close if this isn't a direction you want. Thanks again for the project!
